### PR TITLE
Add shadow for sticky scroll

### DIFF
--- a/themes/github-plus-theme.json
+++ b/themes/github-plus-theme.json
@@ -32,6 +32,8 @@
     "notification.background": "#54a3ff",
     "editorGroupHeader.tabsBackground": "#fafbfc",
     "editorGroupHeader.tabsBorder": "#e1e4e8",
+    "editorStickyScroll.shadow": "#c0c0c0",
+    "sideBarStickyScroll.shadow": "#c0c0c0",
     "tab.activeBackground": "#ffffff",
     "tab.activeBorder": "#e36209",
     "tab.inactiveBackground": "#fafbfc",


### PR DESCRIPTION
The sticky scroll sections were not visible correctly.

Before:
<img width="1136" alt="Screenshot 2024-11-28 at 12 40 34 PM" src="https://github.com/user-attachments/assets/3b360646-c55e-428c-8333-d3206c4e6010">

After:
<img width="1136" alt="Screenshot 2024-11-28 at 12 37 55 PM" src="https://github.com/user-attachments/assets/34f65d5a-6325-4a5d-a747-26e7dbe210cb">
